### PR TITLE
Documentation, various fixes, additions & changes

### DIFF
--- a/lib/expandable_bottom_bar.dart
+++ b/lib/expandable_bottom_bar.dart
@@ -1,3 +1,4 @@
+/// Bottom app bar with an animated, expandable content body
 library expandable_bottom_bar;
 
 export 'package:expandable_bottom_bar/src/controller.dart';

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -17,7 +17,8 @@ class BottomBarController extends ChangeNotifier {
     _animationController.addStatusListener(_statusListener);
   }
 
-  @Deprecated("use state instead. Will be removed soon")
+  @Deprecated(
+      "This is deprecated in favor of `state`, and will be removed in the future")
   Animation<double> get animation =>
       _animationController?.view ?? kAlwaysCompleteAnimation;
 

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,39 +1,52 @@
 import 'package:flutter/material.dart';
 
+/// A listenable controller for use with [BottomExpandableBar],
+/// with behavior-related properties and methods
 class BottomBarController extends ChangeNotifier {
   final bool snap;
   final double dragLength;
 
+  /// Creates a [BottomBarController] with the given [vsync] ticker provider
   BottomBarController({
     @required TickerProvider vsync,
     this.snap: true,
     double dragLength,
   })  : _animationController = AnimationController(vsync: vsync),
         assert(dragLength == null || dragLength > 0),
-        dragLength = dragLength;
+        dragLength = dragLength {
+    _animationController.addStatusListener(_statusListener);
+  }
 
   @Deprecated("use state instead. Will be removed soon")
   Animation<double> get animation =>
       _animationController?.view ?? kAlwaysCompleteAnimation;
 
+  /// Returns the [view] of the internal [AnimationController],
+  /// which cannot mutate the state of the [AnimationController]
   Animation<double> get state =>
       _animationController?.view ?? kAlwaysCompleteAnimation;
 
   final AnimationController _animationController;
 
+  void _statusListener(AnimationStatus status) => notifyListeners();
+
+  /// Updates the internal [AnimationController] with the
+  /// [DragUpdateDetails] of a [GestureDragUpdateCallback]
   void onDrag(DragUpdateDetails details) {
     if (dragLength == null) return;
     _animationController.value -= details.primaryDelta / (dragLength);
   }
 
+  /// Updates the animation according to the [DragEndDetails]
+  /// details of a [GestureDragEndCallback]
   void onDragEnd(DragEndDetails details) {
     if (dragLength == null) return;
     double minFlingVelocity = 365.0;
 
-    //let the current animation finish before starting a new one
+    // Let the current animation finish before starting a new one
     if (_animationController.isAnimating) return;
 
-    //check if the velocity is sufficient to constitute fling
+    // Check if the velocity is sufficient to constitute fling
     if (details.velocity.pixelsPerSecond.dy.abs() >= minFlingVelocity) {
       double visualVelocity =
           -details.velocity.pixelsPerSecond.dy / (dragLength);
@@ -51,7 +64,7 @@ class BottomBarController extends ChangeNotifier {
       return;
     }
 
-    // check if the controller is already halfway there
+    // Check if the controller is already halfway there
     if (snap) {
       if (_animationController.value > 0.5)
         open();
@@ -60,38 +73,56 @@ class BottomBarController extends ChangeNotifier {
     }
   }
 
-  //close the panel
-  void close() {
-    _animationController.fling(velocity: -1.0).then((_) => notifyListeners());
+  /// Closes the panel
+  void close({double velocity = -1.0}) {
+    _animationController.fling(velocity: -velocity.abs());
   }
 
-  void swap() {
-    if (_animationController.value == 1)
-      close();
-    else if (_animationController.value == 0) open();
+  /// Opens the panel if it's currently closed,
+  /// or closes the panel if it's currently open
+  void swap({double velocity = 1.0}) {
+    if (isOpen) {
+      close(velocity: velocity);
+    } else if (isClosed) {
+      open(velocity: velocity);
+    }
   }
 
-  //open the panel
-  void open() {
-    _animationController.fling(velocity: 1.0).then((_) => notifyListeners());
+  /// Opens the panel
+  void open({double velocity = 1.0}) {
+    _animationController.fling(velocity: velocity.abs());
   }
 
-  bool isOpen() {
-    return _animationController.value == 1;
-  }
+  /// Whether the panel is fully opened
+  bool get isOpen => _animationController.status == AnimationStatus.completed;
+
+  /// Whether the panel is fully closed
+  bool get isClosed => _animationController.status == AnimationStatus.dismissed;
+
+  /// Whether the panel is being opened
+  bool get isOpening => _animationController.status == AnimationStatus.forward;
+
+  /// Whether the panel is being closed
+  bool get isClosing => _animationController.status == AnimationStatus.reverse;
 }
 
+/// A widget that provides a default bottom bar controller
+/// to its children
 class DefaultBottomBarController extends StatefulWidget {
+  /// The child of the [DefaultBottomBarController] widget
   final Widget child;
 
+  /// Creates a default [BottomBarController] for the given [child] widget
   DefaultBottomBarController({
     Key key,
     @required this.child,
   }) : super(key: key);
 
+  /// Returns the nearest [BottomBarController] of the
+  /// given [BuildContext]
   static BottomBarController of(BuildContext context) {
     final _BottomBarControllerScope scope =
-        context.inheritFromWidgetOfExactType(_BottomBarControllerScope);
+        context.findAncestorWidgetOfExactType<_BottomBarControllerScope>();
     return scope?.controller;
   }
 

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -2,28 +2,59 @@ import 'package:expandable_bottom_bar/src/controller.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+/// An enum representing different sides of a screen
 enum Side { Top, Bottom }
 
+/// Bottom app bar with an animated, expandable content body
 class BottomExpandableAppBar extends StatefulWidget {
+  /// The content visible when the [BottomExpandableAppBar]
+  /// is expanded
   final Widget expandedBody;
+
+  /// The height of the expanded [BottomExpandableAppBar]
   final double expandedHeight;
+
+  /// The content of the bottom app bar
   final Widget bottomAppBarBody;
+
+  /// A [BottomBarController] to use with the
+  /// [BottomExpandableAppBar]
   final BottomBarController controller;
+
+  /// A [Side] which determines which side of the
+  /// screen the panel is attached to
   final Side attachSide;
 
+  /// Height of the bottom app bar
   final double appBarHeight;
   // TODO: Get max available height
   final bool useMax;
 
+  /// [BoxConstraints] which determines the final height
+  /// of the panel
   final BoxConstraints constraints;
 
+  /// [NotchedShape] shape for a [FloatingActionButton]
   final NotchedShape shape;
+
+  /// Background [Color] for the panel
   final Color expandedBackColor;
+
+  /// [Color] of the bottom app bar
   final Color bottomAppBarColor;
+
+  /// Margin on the horizontal axis
+  /// for the bottom app bar content
   final double horizontalMargin;
+
+  /// Offset for the content from
+  /// the bottom of the bottom app bar
   final double bottomOffset;
 
+  /// [Decoration] for the panel container
   final Decoration expandedDecoration;
+
+  /// [Decoration] for the bottom app bar
   final Decoration appBarDecoration;
 
   BottomExpandableAppBar({
@@ -76,8 +107,7 @@ class _BottomExpandableAppBarState extends State<BottomExpandableAppBar> {
   @override
   void dispose() {
     if (_controller != null)
-      _controller.state
-          .removeListener(_handleBottomBarControllerAnimationTick);
+      _controller.state.removeListener(_handleBottomBarControllerAnimationTick);
     // We don't own the _controller Animation, so it's not disposed here.
     super.dispose();
   }
@@ -99,13 +129,11 @@ class _BottomExpandableAppBarState extends State<BottomExpandableAppBar> {
     if (newController == _controller) return;
 
     if (_controller != null) {
-      _controller.state
-          .removeListener(_handleBottomBarControllerAnimationTick);
+      _controller.state.removeListener(_handleBottomBarControllerAnimationTick);
     }
     _controller = newController;
     if (_controller != null) {
-      _controller.state
-          .addListener(_handleBottomBarControllerAnimationTick);
+      _controller.state.addListener(_handleBottomBarControllerAnimationTick);
     }
   }
 
@@ -119,7 +147,7 @@ class _BottomExpandableAppBarState extends State<BottomExpandableAppBar> {
       color: Colors.transparent,
       elevation: 0,
       child: Stack(
-        //TODO: Find out how to get top app bar overlap body content of scaffold 
+        //TODO: Find out how to get top app bar overlap body content of scaffold
         alignment: widget.attachSide == Side.Bottom
             ? Alignment.bottomCenter
             : Alignment.topCenter,
@@ -148,7 +176,7 @@ class _BottomExpandableAppBarState extends State<BottomExpandableAppBar> {
           ),
           // * Mask content of bottom container in notch
           Container(
-            // some mask code
+            // Some mask code
             height: widget.appBarHeight,
           ),
           ClipPath(
@@ -173,7 +201,7 @@ class _BottomExpandableAppBarState extends State<BottomExpandableAppBar> {
   }
 }
 
-//Copied from flutter sdk
+// Copied from Flutter SDK
 class _BottomAppBarClipper extends CustomClipper<Path> {
   const _BottomAppBarClipper(
       {@required this.geometry,


### PR DESCRIPTION
**BREAKING**:
- [x] Changed `isOpen` from a method to a getter

Backwards-compatible:
- [x] Documented public members & methods
- [x] Replaced deprecated `inheritFromWidgetOfExactType` with `findAncestorWidgetOfExactType`
- [x] Added getters isOpen, isOpening, isClosed, isClosing
- [x] Changed to AnimationStatus for status checking
- [x] Controller notifies listeners when animation status is updated, not just on completion
- [x] Added optional named `velocity` parameter to `close`, `open` and `swap` methods
- [x] Clarified deprecation message for `animation` getter

Since the API has a breaking change, this should receive a major version bump and changelog update (not added here). If undesirable, it could of course be done in a backwards-compatible manner by retaining the `isOpen` method and changing name on the getter.